### PR TITLE
Magento 2.4.3 Compatability

### DIFF
--- a/Helper/Data.php
+++ b/Helper/Data.php
@@ -36,7 +36,11 @@ class Data extends AbstractHelper
      */
     public function isCustomerEditAdminPage()
     {
-        return $this->_request->getFullActionName() === 'customer_index_edit';
+        return $this->_request->getFullActionName() === 'customer_index_edit' ||
+            (
+                $this->_request->getFullActionName() === 'mui_index_render_handle' &&
+                $this->_request->getParam('handle') === 'customer_address_edit'
+            ); // Address form uses MUI renderer since ~2.4
     }
 
     /**

--- a/Plugin/Component/AbstractComponentPlugin.php
+++ b/Plugin/Component/AbstractComponentPlugin.php
@@ -37,9 +37,17 @@ class AbstractComponentPlugin
     public function afterGetChildComponents(AbstractComponent $subject, $result)
     {
         if ($this->_dataHelper->isCustomerEditAdminPage() && $this->_dataHelper->isEnabled()) {
+
+            $dataProvider = $subject->getContext()->getDataProvider()->getName();
+
             if ($subject->getName() == 'customer') {
                 $this->hideFields($result, $this->_dataHelper->getCustomerAttributeArray());
-            } elseif ($subject->getName() == 'address') {
+            } elseif (
+                // Address form fields are in a separate UI component XML from ~2.4
+                // Using data source to identify correct component to match
+                ($dataProvider == 'customer_address_form_data_source' && $subject->getName() == 'general') ||
+                ($dataProvider == 'customer_form_data_source' && $subject->getName() == 'address')
+            ) {
                 $this->hideFields($result, $this->_dataHelper->getCustomerAddressAttributeArray());
             }
         }

--- a/composer.json
+++ b/composer.json
@@ -31,7 +31,7 @@
         "magepal/magento2-core": ">=1.1.10"
     },
     "type": "magento2-module",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "autoload": {
         "files": [
             "registration.php"


### PR DESCRIPTION
Fixes for two bugs that prevented customer address fields
from being removed on the customer edit page. Since ~2.4,
the way address form works has changed.

- Customer address form is now loaded via ajax. An additional
  condition has been added to isCustomerEditAdminPage
  to handle this request.
- Customer address fields are now defined inside a separate
  ui component XML file, customer_address_form.xml.
  afterGetChildComponents plugin has been modified to check
  for the new fieldset.